### PR TITLE
Preserves path of files in from directory 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ TransferWebpackPlugin.prototype.processDir = function(from, to, compilation) {
         }
 
         var allFiles = files.map(function(fullPath) {
-            var fileName = path.basename(fullPath);
+            var fileName = fullPath.replace(from, '');
             var distName = to ? path.join(to, fileName) : fileName;
 
             compilation.assets[distName] = {


### PR DESCRIPTION
The pull request https://github.com/molforp/transfer-webpack-plugin/pull/4 reverted the fixes from https://github.com/molforp/transfer-webpack-plugin/pull/2.

So here is another try :)
